### PR TITLE
Fix url formatting for clear_failed_records function in usage client

### DIFF
--- a/amieclient/client.py
+++ b/amieclient/client.py
@@ -477,7 +477,7 @@ class UsageClient:
 
         fids = ','.join(failed_ids)
 
-        url = self.usage_url + 'usage/failed/{fids}'.format(fids)
+        url = self.usage_url + 'usage/failed/{}'.format(fids)
 
         r = self._session.delete(url)
         r.raise_for_status()


### PR DESCRIPTION
Current code attempts to access the format arguments by name, but the fids variable isn't passed by name to the format function.  Fixed by accessing the format arguments by position by using {} instead of {fids} since this seems to be the pattern used throughout the client module.