### PR TITLE
Don't check value before checking existence of packet date

### DIFF
--- a/amieclient/packet/base.py
+++ b/amieclient/packet/base.py
@@ -335,7 +335,7 @@ class Packet(object, metaclass=MetaPacket):
             'packet_state': self.packet_state,
             'packet_timestamp': self.packet_timestamp,
         }
-        if self.date is not None:
+        if hasattr(self, 'date') and self.date is not None:
             header['date'] = self.date.isoformat()
         if self.in_reply_to_id:
             header['in_reply_to'] = self.in_reply_to_id


### PR DESCRIPTION
In practice the date attribute is not always set on a packet, test for existence before testing for value. 

>>> import amieclient
>>> client = amieclient.AMIEClient(site_name=site, api_key=secret,)
>>> packetlist = client.list_packets()
>>> [x for x in packetlist.packets if x.packet_type=='request_project_create'][32].as_dict()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/src/amie_client/lib/python3.8/site-packages/amieclient/packet/base.py", line 338, in as_dict
    if self.date is not None:
AttributeError: 'RequestProjectCreate' object has no attribute 'date'