### PR TITLE
Allow newer Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     author='G. Ryan Sablosky',
     author_email='sablosky@psc.edu',
-    python_requires='>=3.5,<3.10',
+    python_requires='>=3.5',
     description='Library for the XSEDE AMIE REST API.',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
In `setup.py`, remove the restriction on Python 3.10 or newer. This is required to use the package on Ubuntu 22.04.